### PR TITLE
Added docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:2.7.11
+
+RUN apt-get update && \
+    apt-get install -y wget unzip && \
+    apt-get install -y libzookeeper-mt-dev && \
+    pip install zkpython
+
+RUN wget https://github.com/phunt/zk-smoketest/archive/master.zip -O zk-smoketest.zip; \
+    unzip zk-smoketest.zip; \
+    rm zk-smoketest.zip
+
+EXPOSE 2181
+
+ENTRYPOINT ["zk-smoketest-master/zk-latencies.py"]


### PR DESCRIPTION
You probably don't need to do the wget and unzip,  but I thought this was a good first pass for people who don't want to have to install python and dependencies onto their system.

How to use (localhost):
docker run --rm [IMAGENAME]

You have to enable host networking if you want localhost:2181 to work, otherwise you can set the --server option